### PR TITLE
Implement allowing to skip merges of NSManagedObjects

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
@@ -68,7 +68,7 @@
 
 @protocol MagicalRecord_MergeSkippable <NSObject>
 
-- (BOOL) MR_maySkipMerging;
+- (BOOL) MR_shouldSkipMerging;
 
 @end
 

--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalRecord.h
@@ -66,6 +66,12 @@
 
 @end
 
+@protocol MagicalRecord_MergeSkippable <NSObject>
+
+- (BOOL) MR_maySkipMerging;
+
+@end
+
 #pragma mark - Deprecated Methods — DO NOT USE
 @interface NSManagedObject (MagicalRecordDeprecated)
 

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -250,8 +250,8 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
     NSSet *updatedObjects = [[notification userInfo] objectForKey:NSUpdatedObjectsKey];
 
     NSSet *nonSkippableObjects = [updatedObjects filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
-        if ([evaluatedObject respondsToSelector:@selector(MR_maySkipMerging)]) {
-            return ![evaluatedObject MR_maySkipMerging];
+        if ([evaluatedObject respondsToSelector:@selector(MR_shouldSkipMerging)]) {
+            return ![evaluatedObject MR_shouldSkipMerging];
         }
         return YES;
     }]];

--- a/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
+++ b/MagicalRecord/Categories/NSManagedObjectContext/NSManagedObjectContext+MagicalRecord.m
@@ -12,6 +12,7 @@
 #import "MagicalRecord+ErrorHandling.h"
 #import "MagicalRecord+iCloud.h"
 #import "MagicalRecordLogging.h"
+#import "NSManagedObject+MagicalRecord.h"
 
 static NSString * const MagicalRecordContextWorkingName = @"MagicalRecordContextWorkingName";
 
@@ -212,9 +213,15 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
     }
 }
 
-+ (void)rootContextDidSave:(NSNotification *)notification
++ (void) rootContextDidSave:(NSNotification *)notification
 {
     if ([notification object] != [self MR_rootSavingContext])
+    {
+        return;
+    }
+
+    NSNotification *filteredNotification = [self notificationWithFilteredObjects:notification];
+    if ([self isContextDidSaveNotificationEmpty:filteredNotification])
     {
         return;
     }
@@ -222,21 +229,48 @@ static id MagicalRecordUbiquitySetupNotificationObserver;
     if ([NSThread isMainThread] == NO)
     {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self rootContextDidSave:notification];
+            [self rootContextDidSave:filteredNotification];
         });
 
         return;
     }
 
-    for (NSManagedObject *object in [[notification userInfo] objectForKey:NSUpdatedObjectsKey])
+    for (NSManagedObject *object in [[filteredNotification userInfo] objectForKey:NSUpdatedObjectsKey])
     {
         [[[self MR_defaultContext] objectWithID:[object objectID]] willAccessValueForKey:nil];
     }
 
-    [[self MR_defaultContext] mergeChangesFromContextDidSaveNotification:notification];
+    [[self MR_defaultContext] mergeChangesFromContextDidSaveNotification:filteredNotification];
 }
 
 #pragma mark - Private Methods
+
++ (NSNotification *) notificationWithFilteredObjects:(NSNotification *)notification
+{
+    NSSet *updatedObjects = [[notification userInfo] objectForKey:NSUpdatedObjectsKey];
+
+    NSSet *nonSkippableObjects = [updatedObjects filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        if ([evaluatedObject respondsToSelector:@selector(MR_maySkipMerging)]) {
+            return ![evaluatedObject MR_maySkipMerging];
+        }
+        return YES;
+    }]];
+
+    NSMutableDictionary *newUserInfo = [notification.userInfo mutableCopy];
+    newUserInfo[NSUpdatedObjectsKey] = nonSkippableObjects;
+
+    NSNotification *newNotification = [[NSNotification alloc] initWithName:notification.name object:notification.object userInfo:[newUserInfo copy]];
+
+    return newNotification;
+}
+
++ (BOOL) isContextDidSaveNotificationEmpty:(NSNotification *)notification
+{
+    return
+        [notification.userInfo[NSInsertedObjectsKey] count] == 0 &&
+        [notification.userInfo[NSUpdatedObjectsKey] count] == 0 &&
+        [notification.userInfo[NSDeletedObjectsKey] count] == 0;
+}
 
 + (void) MR_cleanUp
 {


### PR DESCRIPTION
Ref: https://paper.dropbox.com/doc/Twist-iOS-performance-improvements-DO-retrospect-I8nc6k8cJ7gaoKrdW3Owp#:h2=Solving-performance-problem-wi

I considered also patching it instead of forking, i.e. removing `NSManagedObject` class from observing `NSManagedObjectContextDidSave` and putting our observer with similar but adjusted code. However that seemed even worse option for maintaining it and it also wasn't very clean since it's static observer instead of instance observer. 

Forking and making explicit changes makes it easier to track them IMO.

Note that there has been a plan to move away from MagicalRecord so in perspective that's probably what we'll do.